### PR TITLE
use __dirname for yarn workspace compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var Funnel = require('broccoli-funnel');
 var merge = require('merge');
 var MergeTrees = require('broccoli-merge-trees');
 var Webfont = require('./utils/webfont');
+var p = require('path');
 
 module.exports = {
   name: 'ember-cli-webfont',
@@ -48,7 +49,7 @@ module.exports = {
     // the addon or your app.
     var dummyWatchDir = 'vendor/';
     if (!this.isDevelopingAddon()) {
-      dummyWatchDir = 'node_modules/ember-cli-webfont/' + dummyWatchDir;
+      dummyWatchDir = p.join(__dirname, dummyWatchDir);
     }
     return new MergeTrees([dummyWatchDir, cssTree], { overwrite: true });
   },


### PR DESCRIPTION
This makes it so that the ember-cli-webfont directory can still be found even if its in a higher up node_modules directory like when yarn workspaces is used.