### PR TITLE
Include cssDest in treeForStyles regardless of extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var merge = require('merge');
 var MergeTrees = require('broccoli-merge-trees');
 var Webfont = require('./utils/webfont');
 var p = require('path');
+var escapeStringRegexp = require('escape-string-regexp');
 
 module.exports = {
   name: 'ember-cli-webfont',
@@ -40,7 +41,7 @@ module.exports = {
       }, this.options());
     const webfont = new Webfont([path], options);
     const cssTree = new Funnel(webfont, {
-      include: [new RegExp(/\.css$/)]
+      include: [new RegExp(escapeStringRegexp(options.cssDest) + '$')]
     });
 
     // Nasty way to deal with an error when there is no SVG files in the specified path

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "broccoli-merge-trees": "^3.0.0",
     "dirmatch": "^0.1.2",
     "ember-cli-babel": "^6.6.0",
+    "escape-string-regexp": "1.0.5",
     "merge": "^1.2.0",
     "underscore": "^1.9.1",
     "webfonts-generator": "^0.4.0"


### PR DESCRIPTION
With this patch I was able to successfully use an SCSS file as a `cssTemplate`. It should also work for other CSS preprocessors.

Fixes #5 