### PR TITLE
fix: fix default value of the "baseSelector" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ var app = new EmberApp({
       cssTemplate: webfont.templates.css,
       templateOptions: {
         classPrefix: 'iconfont-',
-        baseSelector: 'iconfont'
+        baseSelector: '.iconfont'
       }
     }
   }

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
       cssTemplate: Webfont.templates.css,
       templateOptions: {
         classPrefix: 'iconfont-',
-        baseSelector: 'iconfont'
+        baseSelector: '.iconfont'
       }
     }, webfontOptions.options || {});
   },


### PR DESCRIPTION
In [webfonts-generator@0.4.0](https://github.com/sunflowerdeath/webfonts-generator/blob/master/CHANGELOG.md), the `baseClass` option has been deprecated in favor of `baseSelector`. This has correctly been handled by [ember-cli-webfont@1.0.0](https://github.com/vitch/ember-cli-webfont/blob/master/CHANGELOG.md#v100-2018-08-10), but the default value is still a classname.

This pull request change the default value of the `baseSelector` option to the valid selector `.iconfont`.